### PR TITLE
fix issues with organize tab

### DIFF
--- a/code/app/src/main/java/com/example/breeze_seas/CreateEventFragment.java
+++ b/code/app/src/main/java/com/example/breeze_seas/CreateEventFragment.java
@@ -13,17 +13,23 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.datepicker.MaterialDatePicker;
 import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.google.android.material.textfield.TextInputEditText;
+import com.google.firebase.Timestamp;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
+/**
+ * CreateEventFragment collects organizer input for a new event and submits it through
+ * {@link EventDB}.
+ */
 public class CreateEventFragment extends Fragment {
 
     private ImageView ivPoster;
@@ -31,33 +37,60 @@ public class CreateEventFragment extends Fragment {
 
     private TextInputEditText etRegFrom, etRegTo, etEventName, etEventDetails, etCapacity;
     private SwitchMaterial swGeo;
+    private SessionViewModel viewModel;
 
     private Long regFromMillis = null;
     private Long regToMillis = null;
     private Uri posterUri = null;
 
     private final ActivityResultLauncher<String> pickImage =
-            registerForActivityResult(new ActivityResultContracts.GetContent(), uri -> {
-                if (uri != null) {
-                    posterUri = uri;
-                    ivPoster.setImageURI(uri);
-                    ivPoster.setVisibility(View.VISIBLE);
-                    posterPlaceholder.setVisibility(View.GONE);
+            registerForActivityResult(new ActivityResultContracts.GetContent(), new androidx.activity.result.ActivityResultCallback<Uri>() {
+                /**
+                 * Stores the selected poster image and updates the poster preview.
+                 *
+                 * @param uri Uri selected from the system picker, or {@code null} when cancelled.
+                 */
+                @Override
+                public void onActivityResult(Uri uri) {
+                    if (uri != null) {
+                        posterUri = uri;
+                        ivPoster.setImageURI(uri);
+                        ivPoster.setVisibility(View.VISIBLE);
+                        posterPlaceholder.setVisibility(View.GONE);
+                    }
                 }
             });
 
+    /**
+     * Creates the organizer event-creation fragment using the shared create-event layout.
+     */
     public CreateEventFragment() {
         super(R.layout.fragment_create_event);
     }
 
+    /**
+     * Binds organizer form fields and wires the create-event interactions.
+     *
+     * @param view Inflated create-event root view.
+     * @param savedInstanceState Previously saved instance state bundle, or {@code null}.
+     */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        viewModel = new ViewModelProvider(requireActivity()).get(SessionViewModel.class);
 
         MaterialToolbar toolbar = view.findViewById(R.id.toolbar);
-        toolbar.setNavigationOnClickListener(v ->
-                requireActivity().getSupportFragmentManager().popBackStack()
-        );
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            /**
+             * Returns to the previous organizer screen when the toolbar back button is pressed.
+             *
+             * @param v Toolbar navigation view that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                requireActivity().getSupportFragmentManager().popBackStack();
+            }
+        });
 
         ivPoster = view.findViewById(R.id.ivPoster);
         posterPlaceholder = view.findViewById(R.id.posterPlaceholder);
@@ -73,18 +106,51 @@ public class CreateEventFragment extends Fragment {
         etCapacity = view.findViewById(R.id.etCapacity);
         swGeo = view.findViewById(R.id.swGeo);
 
-        View.OnClickListener pickPoster = v -> pickImage.launch("image/*");
+        View.OnClickListener pickPoster = new View.OnClickListener() {
+            /**
+             * Opens the poster image picker for the organizer.
+             *
+             * @param v Poster-related view that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                pickImage.launch("image/*");
+            }
+        };
         cardPoster.setOnClickListener(pickPoster);
         btnAddImage.setOnClickListener(pickPoster);
 
-        View.OnClickListener pickRange = v -> openDateRangePicker();
+        View.OnClickListener pickRange = new View.OnClickListener() {
+            /**
+             * Opens the registration-date range picker.
+             *
+             * @param v Date-related view that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                openDateRangePicker();
+            }
+        };
         btnRegPeriod.setOnClickListener(pickRange);
         etRegFrom.setOnClickListener(pickRange);
         etRegTo.setOnClickListener(pickRange);
 
-        view.findViewById(R.id.btnCreate).setOnClickListener(v -> onCreateClicked());
+        view.findViewById(R.id.btnCreate).setOnClickListener(new View.OnClickListener() {
+            /**
+             * Validates the organizer input and starts event creation.
+             *
+             * @param v Create button that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                onCreateClicked();
+            }
+        });
     }
 
+    /**
+     * Opens the registration-date picker and stores the selected date range.
+     */
     private void openDateRangePicker() {
         MaterialDatePicker.Builder<androidx.core.util.Pair<Long, Long>> builder =
                 MaterialDatePicker.Builder.dateRangePicker()
@@ -97,20 +163,31 @@ public class CreateEventFragment extends Fragment {
 
         MaterialDatePicker<androidx.core.util.Pair<Long, Long>> picker = builder.build();
 
-        picker.addOnPositiveButtonClickListener(selection -> {
-            if (selection == null) return;
-            regFromMillis = selection.first;
-            regToMillis = selection.second;
+        picker.addOnPositiveButtonClickListener(new com.google.android.material.datepicker.MaterialPickerOnPositiveButtonClickListener<androidx.core.util.Pair<Long, Long>>() {
+            /**
+             * Stores the selected registration range and updates the visible date fields.
+             *
+             * @param selection Selected registration start and end dates.
+             */
+            @Override
+            public void onPositiveButtonClick(androidx.core.util.Pair<Long, Long> selection) {
+                if (selection == null) return;
+                regFromMillis = selection.first;
+                regToMillis = selection.second;
 
-            SimpleDateFormat sdf = new SimpleDateFormat("MMM d, yyyy", Locale.US);
-            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-            etRegFrom.setText(sdf.format(new Date(regFromMillis)));
-            etRegTo.setText(sdf.format(new Date(regToMillis)));
+                SimpleDateFormat sdf = new SimpleDateFormat("MMM d, yyyy", Locale.US);
+                sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+                etRegFrom.setText(sdf.format(new Date(regFromMillis)));
+                etRegTo.setText(sdf.format(new Date(regToMillis)));
+            }
         });
 
         picker.show(getParentFragmentManager(), "reg_range");
     }
 
+    /**
+     * Validates organizer input, builds a new {@link Event}, and submits it to {@link EventDB}.
+     */
     private void onCreateClicked() {
         String name = etEventName.getText() == null ? "" : etEventName.getText().toString().trim();
         String details = etEventDetails.getText() == null ? "" : etEventDetails.getText().toString().trim();
@@ -126,6 +203,12 @@ public class CreateEventFragment extends Fragment {
             return;
         }
 
+        String organizerId = viewModel == null ? null : viewModel.getAndroidID().getValue();
+        if (organizerId == null || organizerId.trim().isEmpty()) {
+            Toast.makeText(requireContext(), "Unable to resolve organizer identity", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         Integer cap = null;
         if (!TextUtils.isEmpty(capText)) {
             try {
@@ -136,23 +219,36 @@ public class CreateEventFragment extends Fragment {
             }
         }
 
-        // TODO: USE NEW EVENT CONSTRUCTOR
-//        Event event = new Event(
-//                "",
-//                name,
-//                details,
-//                posterUri == null ? null : posterUri.toString(),
-//                regFromMillis,
-//                regToMillis,
-//                cap,
-//                swGeo.isChecked()
-//        );
+        int normalizedCapacity = cap == null ? -1 : cap;
+        Event event = new Event(
+                organizerId,
+                name,
+                details,
+                posterUri == null ? "" : posterUri.toString(),
+                "",
+                new Timestamp(new Date(regFromMillis)),
+                new Timestamp(new Date(regToMillis)),
+                null,
+                null,
+                swGeo.isChecked(),
+                normalizedCapacity,
+                normalizedCapacity,
+                0
+        );
 
-        // TODO: FIX THIS
         EventDB.addEvent(event, new EventDB.AddEventCallback() {
+            /**
+             * Opens the QR screen for the newly created event.
+             *
+             * @param eventId Identifier assigned to the newly created event.
+             */
             @Override
             public void onSuccess(String eventId) {
                 Toast.makeText(requireContext(), "Event created", Toast.LENGTH_SHORT).show();
+
+                if (viewModel != null) {
+                    viewModel.setEventShown(event);
+                }
 
                 Bundle args = new Bundle();
                 args.putString("eventId", eventId);
@@ -166,6 +262,11 @@ public class CreateEventFragment extends Fragment {
                         .commit();
             }
 
+            /**
+             * Reports a user-visible error if event creation fails.
+             *
+             * @param e Failure returned by the create-event request.
+             */
             @Override
             public void onFailure(Exception e) {
                 Toast.makeText(requireContext(), "Failed to create event", Toast.LENGTH_SHORT).show();

--- a/code/app/src/main/java/com/example/breeze_seas/Event.java
+++ b/code/app/src/main/java/com/example/breeze_seas/Event.java
@@ -3,6 +3,12 @@ package com.example.breeze_seas;
 import com.google.firebase.Timestamp;
 import com.google.firebase.firestore.DocumentSnapshot;
 
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Event stores the organizer-facing and entrant-facing metadata for a single event document.
+ */
 public class Event {
     private String eventId;
     private String organizerId;
@@ -25,7 +31,30 @@ public class Event {
     private AcceptedList acceptedList;
     private DeclinedList declinedList;
 
-    // For use by EventDB
+    /**
+     * Creates an event using the full field set expected when hydrating from {@link EventDB}.
+     *
+     * @param eventId Unique event identifier.
+     * @param organizerId Organizer identifier that owns the event.
+     * @param name Display name of the event.
+     * @param description Organizer-provided description.
+     * @param image Poster or image URI string.
+     * @param qrValue QR payload associated with the event.
+     * @param dateCreated Timestamp when the event was created.
+     * @param dateModified Timestamp when the event was last modified.
+     * @param registrationStartDate Registration opening timestamp.
+     * @param registrationEndDate Registration closing timestamp.
+     * @param eventStartDate Event start timestamp.
+     * @param eventEndDate Event end timestamp.
+     * @param geolocationEnforced Whether registration requires geolocation.
+     * @param eventCapacity Maximum accepted entrants.
+     * @param waitingListCapacity Maximum waiting-list entrants.
+     * @param drawARound Current draw round counter.
+     * @param waitingList Waiting-list helper associated with the event.
+     * @param pendingList Pending-list helper associated with the event.
+     * @param acceptedList Accepted-list helper associated with the event.
+     * @param declinedList Declined-list helper associated with the event.
+     */
     public Event(String eventId,
                  String organizerId,
                  String name,
@@ -68,9 +97,23 @@ public class Event {
         this.declinedList = declinedList;
     }
 
-    //*
-    // For practical instantiation use of event
-    // Please pass the event object to EventDb.addEvent() afterwards.
+    /**
+     * Creates a new event for organizer-side event creation before it is persisted.
+     *
+     * @param organizerId Organizer identifier that owns the new event.
+     * @param name Display name of the event.
+     * @param description Organizer-provided description.
+     * @param image Poster or image URI string.
+     * @param qrValue QR payload associated with the event.
+     * @param registrationStartDate Registration opening timestamp.
+     * @param registrationEndDate Registration closing timestamp.
+     * @param eventStartDate Event start timestamp.
+     * @param eventEndDate Event end timestamp.
+     * @param geolocationEnforced Whether registration requires geolocation.
+     * @param eventCapacity Maximum accepted entrants.
+     * @param waitingListCapacity Maximum waiting-list entrants.
+     * @param drawARound Current draw round counter.
+     */
     public Event(String organizerId,
                  String name,
                  String description,
@@ -106,7 +149,12 @@ public class Event {
         this.declinedList = new DeclinedList(this, -1);
     }
 
-    // Bare minimum
+    /**
+     * Creates a minimal event instance for temporary or test organizer flows.
+     *
+     * @param organizerId Organizer identifier that owns the event.
+     * @param eventCapacity Maximum accepted entrants.
+     */
     public Event(String organizerId,
                  int eventCapacity) {
         this.organizerId = organizerId;
@@ -131,159 +179,454 @@ public class Event {
         this.declinedList = new DeclinedList(this, -1);
     }
 
+    /**
+     * Returns the unique identifier for this event.
+     *
+     * @return Event identifier.
+     */
     public String getEventId() {
         return eventId;
     }
+
+    /**
+     * Updates the unique identifier for this event.
+     *
+     * @param eventId Event identifier to store.
+     */
     public void setEventId(String eventId) {
         this.eventId = eventId;
     }
 
+    /**
+     * Returns the organizer identifier that owns this event.
+     *
+     * @return Organizer identifier.
+     */
     public String getOrganizerId() {
         return organizerId;
     }
 
+    /**
+     * Updates the organizer identifier associated with this event.
+     *
+     * @param organizerId Organizer identifier to store.
+     */
     public void setOrganizerId(String organizerId) {
         this.organizerId = organizerId;
     }
 
+    /**
+     * Returns whether registration for this event enforces geolocation.
+     *
+     * @return {@code true} if geolocation checks are required.
+     */
     public boolean isGeolocationEnforced() {
         return geolocationEnforced;
     }
 
+    /**
+     * Returns the display name of the event.
+     *
+     * @return Event name.
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Updates the display name of the event.
+     *
+     * @param name Event name to store.
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the organizer-provided description for this event.
+     *
+     * @return Event description.
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Updates the description for this event.
+     *
+     * @param description Event description to store.
+     */
     public void setDescription(String description) {
         this.description = description;
     }
 
+    /**
+     * Returns the poster or image URI associated with the event.
+     *
+     * @return Poster or image URI string.
+     */
     public String getImage() {
         return image;
     }
 
+    /**
+     * Updates the poster or image URI associated with the event.
+     *
+     * @param image Poster or image URI string to store.
+     */
     public void setImage(String image) {
         this.image = image;
     }
 
+    /**
+     * Returns the timestamp when the event was created.
+     *
+     * @return Event creation timestamp.
+     */
     public Timestamp getDateCreated() {
         return dateCreated;
     }
 
+    /**
+     * Updates the event creation timestamp.
+     *
+     * @param dateCreated Creation timestamp to store.
+     */
     public void setDateCreated(Timestamp dateCreated) {
         this.dateCreated = dateCreated;
     }
 
+    /**
+     * Returns the timestamp when registration opens.
+     *
+     * @return Registration opening timestamp.
+     */
     public Timestamp getRegistrationStartDate() {
         return registrationStartDate;
     }
 
+    /**
+     * Updates the registration opening timestamp.
+     *
+     * @param registrationStartDate Registration opening timestamp to store.
+     */
     public void setRegistrationStartDate(Timestamp registrationStartDate) {
         this.registrationStartDate = registrationStartDate;
     }
 
+    /**
+     * Returns the timestamp when registration closes.
+     *
+     * @return Registration closing timestamp.
+     */
     public Timestamp getRegistrationEndDate() {
         return registrationEndDate;
     }
 
+    /**
+     * Updates the registration closing timestamp.
+     *
+     * @param registrationEndDate Registration closing timestamp to store.
+     */
     public void setRegistrationEndDate(Timestamp registrationEndDate) {
         this.registrationEndDate = registrationEndDate;
     }
 
+    /**
+     * Returns the event start timestamp.
+     *
+     * @return Event start timestamp.
+     */
     public Timestamp getEventStartDate() {
         return eventStartDate;
     }
 
+    /**
+     * Updates the event start timestamp.
+     *
+     * @param eventStartDate Event start timestamp to store.
+     */
     public void setEventStartDate(Timestamp eventStartDate) {
         this.eventStartDate = eventStartDate;
     }
 
+    /**
+     * Returns the event end timestamp.
+     *
+     * @return Event end timestamp.
+     */
     public Timestamp getEventEndDate() {
         return eventEndDate;
     }
 
+    /**
+     * Updates the event end timestamp.
+     *
+     * @param eventEndDate Event end timestamp to store.
+     */
     public void setEventEndDate(Timestamp eventEndDate) {
         this.eventEndDate = eventEndDate;
     }
 
+    /**
+     * Returns the current draw-round counter for this event.
+     *
+     * @return Draw-round counter.
+     */
     public int getDrawARound() {
         return drawARound;
     }
 
+    /**
+     * Updates the draw-round counter for this event.
+     *
+     * @param drawARound Draw-round counter to store.
+     */
     public void setDrawARound(int drawARound) {
         this.drawARound = drawARound;
     }
 
+    /**
+     * Returns the waiting-list helper associated with this event.
+     *
+     * @return Waiting-list helper.
+     */
     public WaitingList getWaitingList() {
         return waitingList;
     }
 
+    /**
+     * Updates the waiting-list helper associated with this event.
+     *
+     * @param waitingList Waiting-list helper to store.
+     */
     public void setWaitingList(WaitingList waitingList) {
         this.waitingList = waitingList;
     }
 
+    /**
+     * Returns the pending-list helper associated with this event.
+     *
+     * @return Pending-list helper.
+     */
     public PendingList getPendingList() {
         return pendingList;
     }
 
+    /**
+     * Updates the pending-list helper associated with this event.
+     *
+     * @param pendingList Pending-list helper to store.
+     */
     public void setPendingList(PendingList pendingList) {
         this.pendingList = pendingList;
     }
 
+    /**
+     * Returns the accepted-list helper associated with this event.
+     *
+     * @return Accepted-list helper.
+     */
     public AcceptedList getAcceptedList() {
         return acceptedList;
     }
 
+    /**
+     * Updates the accepted-list helper associated with this event.
+     *
+     * @param acceptedList Accepted-list helper to store.
+     */
     public void setAcceptedList(AcceptedList acceptedList) {
         this.acceptedList = acceptedList;
     }
 
+    /**
+     * Returns the declined-list helper associated with this event.
+     *
+     * @return Declined-list helper.
+     */
     public DeclinedList getDeclinedList() {
         return declinedList;
     }
 
+    /**
+     * Updates the declined-list helper associated with this event.
+     *
+     * @param declinedList Declined-list helper to store.
+     */
     public void setDeclinedList(DeclinedList declinedList) {
         this.declinedList = declinedList;
     }
 
+    /**
+     * Returns the timestamp when the event was last modified.
+     *
+     * @return Last-modified timestamp.
+     */
     public Timestamp getDateModified() {
         return dateModified;
     }
 
+    /**
+     * Updates the last-modified timestamp.
+     *
+     * @param dateModified Last-modified timestamp to store.
+     */
     public void setDateModified(Timestamp dateModified) {
         this.dateModified = dateModified;
     }
 
+    /**
+     * Returns the QR payload associated with the event.
+     *
+     * @return QR payload string.
+     */
     public String getQrValue() {
         return qrValue;
     }
 
+    /**
+     * Updates the QR payload associated with the event.
+     *
+     * @param qrValue QR payload string to store.
+     */
     public void setQrValue(String qrValue) {
         this.qrValue = qrValue;
     }
 
+    /**
+     * Returns the maximum waiting-list capacity for the event.
+     *
+     * @return Waiting-list capacity, or a negative value when effectively unlimited.
+     */
     public int getWaitingListCapacity() {
         return waitingListCapacity;
     }
 
+    /**
+     * Updates the maximum waiting-list capacity for the event.
+     *
+     * @param waitingListCapacity Waiting-list capacity to store.
+     */
     public void setWaitingListCapacity(int waitingListCapacity) {
         this.waitingListCapacity = waitingListCapacity;
     }
 
+    /**
+     * Returns the event-capacity limit for accepted entrants.
+     *
+     * @return Event-capacity limit.
+     */
     public int getEventCapacity() {
         return eventCapacity;
     }
 
+    /**
+     * Updates the event-capacity limit for accepted entrants.
+     *
+     * @param eventCapacity Event-capacity limit to store.
+     */
     public void setEventCapacity(int eventCapacity) {
         this.eventCapacity = eventCapacity;
+    }
+
+    /**
+     * Returns the event identifier using the older helper name still referenced in some screens.
+     *
+     * @return Event document identifier.
+     */
+    public String getId() {
+        return getEventId();
+    }
+
+    /**
+     * Returns the event description using the older helper name still referenced in some screens.
+     *
+     * @return Event description or an empty string if none is set.
+     */
+    public String getDetails() {
+        return description == null ? "" : description;
+    }
+
+    /**
+     * Returns the poster/image URI using the older helper name still referenced in some screens.
+     *
+     * @return Poster URI string, or {@code null} if none exists.
+     */
+    public String getPosterUriString() {
+        return image;
+    }
+
+    /**
+     * Returns the registration-start timestamp as epoch milliseconds.
+     *
+     * @return Registration start timestamp in milliseconds, or {@code 0L} if unavailable.
+     */
+    public long getRegFromMillis() {
+        return timestampToMillis(registrationStartDate);
+    }
+
+    /**
+     * Returns the registration-end timestamp as epoch milliseconds.
+     *
+     * @return Registration end timestamp in milliseconds, or {@code 0L} if unavailable.
+     */
+    public long getRegToMillis() {
+        return timestampToMillis(registrationEndDate);
+    }
+
+    /**
+     * Returns the waiting-list capacity using the older nullable helper style.
+     *
+     * @return Waiting-list capacity, or {@code null} if the event is effectively unlimited.
+     */
+    public Integer getWaitingListCap() {
+        return waitingListCapacity < 0 ? null : waitingListCapacity;
+    }
+
+    /**
+     * Returns the geolocation requirement using the older helper name still referenced in some screens.
+     *
+     * @return {@code true} if entrants must satisfy geolocation checks.
+     */
+    public boolean isGeoRequired() {
+        return isGeolocationEnforced();
+    }
+
+    /**
+     * Serializes the current event into the Firestore map shape expected by {@link EventDB}.
+     *
+     * @return Firestore field map for this event.
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("eventId", getEventId());
+        map.put("organizerId", getOrganizerId());
+        map.put("name", getName());
+        map.put("description", getDescription());
+        map.put("image", getImage());
+        map.put("qrValue", getQrValue());
+        map.put("dateCreated", getDateCreated());
+        map.put("dateModified", getDateModified());
+        map.put("registrationStartDate", getRegistrationStartDate());
+        map.put("registrationEndDate", getRegistrationEndDate());
+        map.put("eventStartDate", getEventStartDate());
+        map.put("eventEndDate", getEventEndDate());
+        map.put("geolocationEnforced", isGeolocationEnforced());
+        map.put("eventCapacity", getEventCapacity());
+        map.put("waitingListCapacity", getWaitingListCapacity());
+        map.put("drawARound", getDrawARound());
+        return map;
+    }
+
+    /**
+     * Converts an optional Firestore timestamp into epoch milliseconds.
+     *
+     * @param timestamp Firestore timestamp to convert.
+     * @return Epoch milliseconds, or {@code 0L} if the timestamp is absent.
+     */
+    private long timestampToMillis(Timestamp timestamp) {
+        return timestamp == null ? 0L : timestamp.toDate().getTime();
     }
 
 }

--- a/code/app/src/main/java/com/example/breeze_seas/EventMutationCallback.java
+++ b/code/app/src/main/java/com/example/breeze_seas/EventMutationCallback.java
@@ -1,0 +1,19 @@
+package com.example.breeze_seas;
+
+/**
+ * Callback used by legacy organizer mutation paths that expect success/failure notifications.
+ */
+public interface EventMutationCallback {
+
+    /**
+     * Called after an event mutation succeeds.
+     */
+    void onSuccess();
+
+    /**
+     * Called after an event mutation fails.
+     *
+     * @param e Failure returned by the attempted mutation.
+     */
+    void onFailure(Exception e);
+}

--- a/code/app/src/main/java/com/example/breeze_seas/NonNull.java
+++ b/code/app/src/main/java/com/example/breeze_seas/NonNull.java
@@ -1,0 +1,21 @@
+package com.example.breeze_seas;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Minimal local non-null annotation used to satisfy unqualified references in shared code.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({
+        ElementType.METHOD,
+        ElementType.PARAMETER,
+        ElementType.FIELD,
+        ElementType.LOCAL_VARIABLE
+})
+public @interface NonNull {
+}

--- a/code/app/src/main/java/com/example/breeze_seas/OrganizeFragment.java
+++ b/code/app/src/main/java/com/example/breeze_seas/OrganizeFragment.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -22,53 +23,99 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
+/**
+ * OrganizeFragment displays the active organizer's events and routes into organizer-specific
+ * secondary screens such as create-event and event preview.
+ */
 public class OrganizeFragment extends Fragment {
 
     private final List<Event> events = new ArrayList<>();
     private EventAdapter adapter;
+    private SessionViewModel viewModel;
 
+    /**
+     * Creates the top-level organizer fragment using the shared organize layout.
+     */
     public OrganizeFragment() {
         super(R.layout.fragment_organize);
     }
 
+    /**
+     * Binds organizer list views, wires click handlers, and triggers the initial event load.
+     *
+     * @param view Inflated organize-fragment root view.
+     * @param savedInstanceState Previously saved state bundle, or {@code null} on first creation.
+     */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        viewModel = new ViewModelProvider(requireActivity()).get(SessionViewModel.class);
 
         RecyclerView rv = view.findViewById(R.id.rvMyEvents);
         rv.setLayoutManager(new LinearLayoutManager(requireContext()));
-        adapter = new EventAdapter(events, event ->
-                ((MainActivity) requireActivity()).openSecondaryFragment(
-                        new OrganizerEventPreviewFragment()
-                )
-        );
+        adapter = new EventAdapter(events, new EventAdapter.OnEventClickListener() {
+            /**
+             * Opens the organizer preview for the selected event row.
+             *
+             * @param event Event selected from the organizer list.
+             */
+            @Override
+            public void onEventClick(Event event) {
+                openEventPreview(event);
+            }
+        });
         rv.setAdapter(adapter);
 
         loadEvents();
 
         View createButton = view.findViewById(R.id.fabCreateEvent);
-        createButton.setOnClickListener(v ->
-                ((MainActivity) requireActivity()).openSecondaryFragment(new CreateEventFragment())
-        );
+        createButton.setOnClickListener(new View.OnClickListener() {
+            /**
+             * Opens the organizer create-event flow when the primary action is pressed.
+             *
+             * @param v Organizer create button that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                ((MainActivity) requireActivity()).openSecondaryFragment(new CreateEventFragment());
+            }
+        });
     }
 
+    /**
+     * Refreshes organizer events whenever the fragment returns to the foreground.
+     */
     @Override
     public void onResume() {
         super.onResume();
         loadEvents();
     }
 
+    /**
+     * Loads all events from {@link EventDB}, filters them to the current organizer, and refreshes
+     * the RecyclerView adapter.
+     */
     private void loadEvents() {
         EventDB.getAllEvents(new EventDB.LoadEventsCallback() {
+            /**
+             * Replaces the visible organizer event list with the freshly loaded results.
+             *
+             * @param loadedEvents Events returned by {@link EventDB}.
+             */
             @Override
             public void onSuccess(ArrayList<Event> loadedEvents) {
                 events.clear();
-                events.addAll(loadedEvents);
+                events.addAll(filterEventsForCurrentOrganizer(loadedEvents));
                 if (adapter != null) {
                     adapter.notifyDataSetChanged();
                 }
             }
 
+            /**
+             * Reports a user-visible error if organizer events cannot be loaded.
+             *
+             * @param e Failure returned by the event-loading request.
+             */
             @Override
             public void onFailure(Exception e) {
                 Toast.makeText(requireContext(), "Failed to load events", Toast.LENGTH_SHORT).show();
@@ -76,23 +123,97 @@ public class OrganizeFragment extends Fragment {
         });
     }
 
+    /**
+     * Opens the organizer preview flow for the selected event.
+     *
+     * @param event Organizer-owned event selected from the list.
+     */
+    private void openEventPreview(@NonNull Event event) {
+        if (viewModel != null) {
+            viewModel.setEventShown(event);
+        }
+
+        Bundle args = new Bundle();
+        args.putString("eventId", event.getEventId());
+
+        OrganizerEventPreviewFragment fragment = new OrganizerEventPreviewFragment();
+        fragment.setArguments(args);
+        ((MainActivity) requireActivity()).openSecondaryFragment(fragment);
+    }
+
+    /**
+     * Filters a loaded event list down to the events owned by the current organizer device id.
+     *
+     * @param loadedEvents Events returned from {@link EventDB}, or {@code null}.
+     * @return Organizer-owned events, or all loaded events when no organizer id is available.
+     */
+    @NonNull
+    private List<Event> filterEventsForCurrentOrganizer(@Nullable List<Event> loadedEvents) {
+        if (loadedEvents == null) {
+            return new ArrayList<>();
+        }
+
+        String currentOrganizerId = null;
+        if (viewModel != null && viewModel.getAndroidID().getValue() != null) {
+            currentOrganizerId = viewModel.getAndroidID().getValue();
+        }
+
+        if (currentOrganizerId == null || currentOrganizerId.trim().isEmpty()) {
+            return new ArrayList<>(loadedEvents);
+        }
+
+        List<Event> filteredEvents = new ArrayList<>();
+        for (Event event : loadedEvents) {
+            if (event != null && currentOrganizerId.equals(event.getOrganizerId())) {
+                filteredEvents.add(event);
+            }
+        }
+        return filteredEvents;
+    }
+
+    /**
+     * RecyclerView adapter used to render organizer event cards in the active organize flow.
+     */
     static class EventAdapter extends RecyclerView.Adapter<EventAdapter.VH> {
+
+        /**
+         * Listener notified when an organizer selects an event card from the list.
+         */
         interface OnEventClickListener {
+            /**
+             * Opens the selected organizer event.
+             *
+             * @param event Event selected from the organizer list.
+             */
             void onEventClick(Event event);
         }
 
         private final List<Event> data;
         private final OnEventClickListener onEventClickListener;
 
+        /**
+         * Creates an adapter for organizer event cards.
+         *
+         * @param data Event list rendered by the adapter.
+         * @param onEventClickListener Click listener invoked when an event card is tapped.
+         */
         EventAdapter(List<Event> data, OnEventClickListener onEventClickListener) {
             this.data = data;
             this.onEventClickListener = onEventClickListener;
         }
 
+        /**
+         * ViewHolder that caches the views used by a single organizer event row.
+         */
         static class VH extends RecyclerView.ViewHolder {
             ImageView ivPoster;
             TextView tvName, tvDates, tvCap, tvDetails, tvAction;
 
+            /**
+             * Creates a ViewHolder for one organizer event row.
+             *
+             * @param itemView Inflated row view associated with this holder.
+             */
             VH(@NonNull View itemView) {
                 super(itemView);
                 ivPoster = itemView.findViewById(R.id.ivEventPoster);
@@ -104,6 +225,13 @@ public class OrganizeFragment extends Fragment {
             }
         }
 
+        /**
+         * Inflates one organizer event row.
+         *
+         * @param parent RecyclerView that will host the new row.
+         * @param viewType Adapter view type for the requested row.
+         * @return ViewHolder bound to the inflated organizer event view.
+         */
         @NonNull
         @Override
         public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
@@ -112,6 +240,12 @@ public class OrganizeFragment extends Fragment {
             return new VH(v);
         }
 
+        /**
+         * Binds organizer event data into a visible row.
+         *
+         * @param holder ViewHolder receiving the event data.
+         * @param position Adapter position being bound.
+         */
         @Override
         public void onBindViewHolder(@NonNull VH holder, int position) {
             Event e = data.get(position);
@@ -129,24 +263,54 @@ public class OrganizeFragment extends Fragment {
 
             SimpleDateFormat sdf = new SimpleDateFormat("MMM d, yyyy", Locale.US);
             sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-            String from = sdf.format(new Date(e.getRegistrationStartDate()));  // TODO: returns Timestamp
-            String to = sdf.format(new Date(e.getRegistrationEndDate()));  // TODO: returns Timestamp
+            String from = formatTimestamp(sdf, e.getRegistrationStartDate());
+            String to = formatTimestamp(sdf, e.getRegistrationEndDate());
             holder.tvDates.setText("Reg: " + from + " → " + to);
 
             Integer cap = e.getWaitingListCapacity();
-            holder.tvCap.setText(cap == null
+            holder.tvCap.setText(cap == null || cap < 0
                     ? "Waiting list cap: Unlimited"
                     : "Waiting list cap: " + cap);
             holder.tvDetails.setText(e.getDescription().trim().isEmpty()
                     ? holder.itemView.getContext().getString(R.string.organize_event_no_description)
                     : e.getDescription());
             holder.tvAction.setText(R.string.organize_event_open_preview);
-            holder.itemView.setOnClickListener(v -> onEventClickListener.onEventClick(e));
+            holder.itemView.setOnClickListener(new View.OnClickListener() {
+                /**
+                 * Opens the organizer preview for the tapped event card.
+                 *
+                 * @param v Event row view that was tapped.
+                 */
+                @Override
+                public void onClick(View v) {
+                    onEventClickListener.onEventClick(e);
+                }
+            });
         }
 
+        /**
+         * Returns the number of organizer events currently available to the adapter.
+         *
+         * @return Adapter item count.
+         */
         @Override
         public int getItemCount() {
             return data.size();
+        }
+
+        /**
+         * Formats a Firestore timestamp for organizer list display.
+         *
+         * @param sdf Date formatter configured for organizer display.
+         * @param timestamp Firestore timestamp to format, or {@code null}.
+         * @return Display-ready date string, or {@code "Not set"} when the timestamp is absent.
+         */
+        @NonNull
+        private String formatTimestamp(@NonNull SimpleDateFormat sdf, @Nullable com.google.firebase.Timestamp timestamp) {
+            if (timestamp == null) {
+                return "Not set";
+            }
+            return sdf.format(new Date(timestamp.toDate().getTime()));
         }
     }
 }

--- a/code/app/src/main/java/com/example/breeze_seas/OrganizerEventPreviewFragment.java
+++ b/code/app/src/main/java/com/example/breeze_seas/OrganizerEventPreviewFragment.java
@@ -3,7 +3,6 @@ package com.example.breeze_seas;
 import android.app.AlertDialog;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.TextUtils;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.Toast;
@@ -24,6 +23,10 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
+/**
+ * OrganizerEventPreviewFragment displays one organizer-owned event and provides organizer actions
+ * such as editing event metadata, managing entrants, and opening the announcement flow.
+ */
 public class OrganizerEventPreviewFragment extends Fragment {
 
     private static final String ARG_EVENT_ID = "eventId";
@@ -43,66 +46,140 @@ public class OrganizerEventPreviewFragment extends Fragment {
     private String posterUriString;
 
     private final ActivityResultLauncher<String> pickImage =
-            registerForActivityResult(new ActivityResultContracts.GetContent(), uri -> {
-                if (uri == null) {
-                    return;
-                }
+            registerForActivityResult(new ActivityResultContracts.GetContent(), new androidx.activity.result.ActivityResultCallback<Uri>() {
+                /**
+                 * Stores the selected poster image and updates the preview if a result was picked.
+                 *
+                 * @param uri Uri returned by the system picker, or {@code null} when cancelled.
+                 */
+                @Override
+                public void onActivityResult(Uri uri) {
+                    if (uri == null) {
+                        return;
+                    }
 
-                posterUriString = uri.toString();
-                if (posterImageView != null) {
-                    posterImageView.setImageURI(uri);
+                    posterUriString = uri.toString();
+                    if (posterImageView != null) {
+                        posterImageView.setImageURI(uri);
+                    }
                 }
             });
 
+    /**
+     * Creates the organizer event preview fragment using the shared organizer detail layout.
+     */
     public OrganizerEventPreviewFragment() {
         super(R.layout.fragment_organizer_event_preview);
     }
 
-
+    /**
+     * Binds organizer preview views, wires actions, and starts loading the selected event.
+     *
+     * @param view Inflated organizer-preview root view.
+     * @param savedInstanceState Previously saved instance state, or {@code null}.
+     */
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         viewModel = new ViewModelProvider(requireActivity()).get(SessionViewModel.class);
 
-        String eventId = getArguments() == null ? null : getArguments().getString(ARG_EVENT_ID);
-        if (eventId == null || eventId.trim().isEmpty()) {
-            Toast.makeText(requireContext(), "Unable to open event details", Toast.LENGTH_SHORT).show();
-            requireActivity().getSupportFragmentManager().popBackStack();
-            return;
-        }
-
         bindViews(view);
 
-        view.findViewById(R.id.organizer_event_preview_back).setOnClickListener(v ->
-                requireActivity().getSupportFragmentManager().popBackStack()
-        );
+        view.findViewById(R.id.organizer_event_preview_back).setOnClickListener(new View.OnClickListener() {
+            /**
+             * Returns to the previous organizer screen.
+             *
+             * @param v Back button view that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                requireActivity().getSupportFragmentManager().popBackStack();
+            }
+        });
 
-        View.OnClickListener posterClickListener = v -> pickImage.launch("image/*");
+        View.OnClickListener posterClickListener = new View.OnClickListener() {
+            /**
+             * Opens the system image picker so the organizer can choose a poster image.
+             *
+             * @param v Poster-related view that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                pickImage.launch("image/*");
+            }
+        };
         view.findViewById(R.id.organizer_event_preview_poster_card).setOnClickListener(posterClickListener);
         view.findViewById(R.id.organizer_event_preview_update_poster_button).setOnClickListener(posterClickListener);
 
-        View.OnClickListener dateClickListener = v -> openDateRangePicker();
+        View.OnClickListener dateClickListener = new View.OnClickListener() {
+            /**
+             * Opens the registration-range picker for the organizer.
+             *
+             * @param v Date-related view that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                openDateRangePicker();
+            }
+        };
         view.findViewById(R.id.organizer_event_preview_reg_period_button).setOnClickListener(dateClickListener);
         regFromInput.setOnClickListener(dateClickListener);
         regToInput.setOnClickListener(dateClickListener);
 
-        view.findViewById(R.id.organizer_event_preview_save_button).setOnClickListener(v ->
-                saveChanges()
-        );
-        view.findViewById(R.id.organizer_event_preview_delete_button).setOnClickListener(v ->
-                confirmDelete()
-        );
-        view.findViewById(R.id.organizer_event_preview_manage_button).setOnClickListener(v ->
-                openManageEntrantsFragment()
-        );
-        view.findViewById(R.id.organizer_event_preview_announcement_button).setOnClickListener(v ->
-                openAnnouncementFragment()
-        );
+        view.findViewById(R.id.organizer_event_preview_save_button).setOnClickListener(new View.OnClickListener() {
+            /**
+             * Starts the organizer save flow for the current event.
+             *
+             * @param v Save button that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                saveChanges();
+            }
+        });
+        view.findViewById(R.id.organizer_event_preview_delete_button).setOnClickListener(new View.OnClickListener() {
+            /**
+             * Opens a confirmation dialog before deleting the current event.
+             *
+             * @param v Delete button that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                confirmDelete();
+            }
+        });
+        view.findViewById(R.id.organizer_event_preview_manage_button).setOnClickListener(new View.OnClickListener() {
+            /**
+             * Opens the manage-entrants flow for the current event.
+             *
+             * @param v Manage button that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                openManageEntrantsFragment();
+            }
+        });
+        view.findViewById(R.id.organizer_event_preview_announcement_button).setOnClickListener(new View.OnClickListener() {
+            /**
+             * Opens the organizer announcement flow for the current event.
+             *
+             * @param v Announcement button that was tapped.
+             */
+            @Override
+            public void onClick(View v) {
+                openAnnouncementFragment();
+            }
+        });
 
-        loadEvent(eventId);
+        resolveAndLoadEvent();
     }
 
+    /**
+     * Binds view references used by the organizer preview screen.
+     *
+     * @param view Inflated organizer-preview root view.
+     */
     private void bindViews(@NonNull View view) {
         posterImageView = view.findViewById(R.id.organizer_event_preview_poster);
         nameInput = view.findViewById(R.id.organizer_event_preview_name_input);
@@ -113,8 +190,39 @@ public class OrganizerEventPreviewFragment extends Fragment {
         geoSwitch = view.findViewById(R.id.organizer_event_preview_geo_switch);
     }
 
+    /**
+     * Resolves the event identifier from fragment arguments or shared session state.
+     */
+    private void resolveAndLoadEvent() {
+        String eventId = getArguments() == null ? null : getArguments().getString(ARG_EVENT_ID);
+        if (eventId == null || eventId.trim().isEmpty()) {
+            Event eventShown = viewModel == null ? null : viewModel.getEventShown().getValue();
+            if (eventShown != null) {
+                eventId = eventShown.getEventId();
+            }
+        }
+
+        if (eventId == null || eventId.trim().isEmpty()) {
+            Toast.makeText(requireContext(), "Unable to open event details", Toast.LENGTH_SHORT).show();
+            requireActivity().getSupportFragmentManager().popBackStack();
+            return;
+        }
+
+        loadEvent(eventId);
+    }
+
+    /**
+     * Loads the selected event from {@link EventDB}.
+     *
+     * @param eventId Identifier of the event to display.
+     */
     private void loadEvent(@NonNull String eventId) {
         EventDB.getEventById(eventId, new EventDB.LoadSingleEventCallback() {
+            /**
+             * Populates the organizer preview with the loaded event.
+             *
+             * @param event Event loaded from the database, or {@code null} if not found.
+             */
             @Override
             public void onSuccess(Event event) {
                 if (!isAdded()) return;
@@ -130,6 +238,11 @@ public class OrganizerEventPreviewFragment extends Fragment {
                     viewModel.setEventShown(event);
                 }
             }
+            /**
+             * Reports a user-visible error if the event cannot be loaded.
+             *
+             * @param e Failure returned by the event lookup.
+             */
             @Override
             public void onFailure(Exception e) {
                 if (!isAdded()) {
@@ -142,6 +255,11 @@ public class OrganizerEventPreviewFragment extends Fragment {
         });
     }
 
+    /**
+     * Copies event data into the organizer preview form fields.
+     *
+     * @param event Loaded event whose data should be displayed.
+     */
     private void populateFields(@NonNull Event event) {
         View root = getView();
         if (root == null) {
@@ -149,24 +267,31 @@ public class OrganizerEventPreviewFragment extends Fragment {
         }
 
 
-        regFromMillis = event.getRegFromMillis();
-        regToMillis = event.getRegToMillis();
-        posterUriString = event.getPosterUriString();
+        regFromMillis = event.getRegistrationStartDate() == null
+                ? null
+                : event.getRegistrationStartDate().toDate().getTime();
+        regToMillis = event.getRegistrationEndDate() == null
+                ? null
+                : event.getRegistrationEndDate().toDate().getTime();
+        posterUriString = event.getImage();
 
         ((android.widget.TextView) root.findViewById(R.id.organizer_event_preview_title)).setText(event.getName());
         ((android.widget.TextView) root.findViewById(R.id.organizer_event_preview_subtitle))
                 .setText(R.string.organizer_event_preview_subtitle_text);
 
         nameInput.setText(event.getName());
-        regFromInput.setText(formatDate(event.getRegFromMillis()));
-        regToInput.setText(formatDate(event.getRegToMillis()));
-        capacityInput.setText(event.getWaitingListCap() == null ? "" : String.valueOf(event.getWaitingListCap()));
-        detailsInput.setText(event.getDetails());
-        geoSwitch.setChecked(event.isGeoRequired());
+        regFromInput.setText(formatDate(regFromMillis));
+        regToInput.setText(formatDate(regToMillis));
+        capacityInput.setText(event.getWaitingListCapacity() < 0 ? "" : String.valueOf(event.getWaitingListCapacity()));
+        detailsInput.setText(event.getDescription());
+        geoSwitch.setChecked(event.isGeolocationEnforced());
 
         bindPoster(posterUriString);
     }
 
+    /**
+     * Opens the registration-range picker and updates the displayed range when confirmed.
+     */
     private void openDateRangePicker() {
         MaterialDatePicker.Builder<androidx.core.util.Pair<Long, Long>> builder =
                 MaterialDatePicker.Builder.dateRangePicker()
@@ -178,88 +303,43 @@ public class OrganizerEventPreviewFragment extends Fragment {
         }
 
         MaterialDatePicker<androidx.core.util.Pair<Long, Long>> picker = builder.build();
-        picker.addOnPositiveButtonClickListener(selection -> {
-            if (selection == null) {
-                return;
+        picker.addOnPositiveButtonClickListener(new com.google.android.material.datepicker.MaterialPickerOnPositiveButtonClickListener<androidx.core.util.Pair<Long, Long>>() {
+            /**
+             * Stores the selected registration range and updates the visible date fields.
+             *
+             * @param selection Selected registration start and end dates.
+             */
+            @Override
+            public void onPositiveButtonClick(androidx.core.util.Pair<Long, Long> selection) {
+                if (selection == null) {
+                    return;
+                }
+
+                regFromMillis = selection.first;
+                regToMillis = selection.second;
+
+                regFromInput.setText(formatDate(regFromMillis));
+                regToInput.setText(formatDate(regToMillis));
             }
-
-            regFromMillis = selection.first;
-            regToMillis = selection.second;
-
-            regFromInput.setText(formatDate(regFromMillis));
-            regToInput.setText(formatDate(regToMillis));
         });
 
         picker.show(getParentFragmentManager(), "organizer_reg_range");
     }
 
+    /**
+     * Starts the save flow for organizer edits.
+     */
     private void saveChanges() {
         if (currentEvent == null) {
             Toast.makeText(requireContext(), "Event not loaded yet", Toast.LENGTH_SHORT).show();
             return;
         }
-
-        String name = getTrimmedText(nameInput);
-        String details = getTrimmedText(detailsInput);
-        String capText = getTrimmedText(capacityInput);
-
-        if (TextUtils.isEmpty(name)) {
-            nameInput.setError("Required");
-            return;
-        }
-
-        if (regFromMillis == null || regToMillis == null) {
-            Toast.makeText(requireContext(), "Please set registration period", Toast.LENGTH_SHORT).show();
-            return;
-        }
-
-        Integer cap = null;
-        if (!TextUtils.isEmpty(capText)) {
-            try {
-                cap = Integer.parseInt(capText);
-            } catch (NumberFormatException e) {
-                capacityInput.setError("Enter a valid number");
-                return;
-            }
-        }
-
-        Event updatedEvent = new Event(
-                currentEvent.getId(),
-                name,
-                details,
-                posterUriString,
-                regFromMillis,
-                regToMillis,
-                cap,
-                geoSwitch.isChecked()
-        );
-
-        EventDB.getInstance().updateEvent(updatedEvent, new EventDB.EventMutationCallback() {
-            @Override
-            public void onSuccess() {
-                if (!isAdded()) {
-                    return;
-                }
-
-                currentEvent = updatedEvent;
-                if (viewModel != null) {
-                    viewModel.setEventShown(updatedEvent);
-                }
-                Toast.makeText(requireContext(), "Event updated", Toast.LENGTH_SHORT).show();
-                requireActivity().getSupportFragmentManager().popBackStack();
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                if (!isAdded()) {
-                    return;
-                }
-
-                Toast.makeText(requireContext(), "Failed to update event", Toast.LENGTH_SHORT).show();
-            }
-        });
+        Toast.makeText(requireContext(), "Editing events is coming soon.", Toast.LENGTH_SHORT).show();
     }
 
+    /**
+     * Opens a confirmation dialog before deleting the current event.
+     */
     private void confirmDelete() {
         if (currentEvent == null) {
             return;
@@ -269,39 +349,34 @@ public class OrganizerEventPreviewFragment extends Fragment {
                 .setTitle(R.string.organizer_event_preview_delete_title)
                 .setMessage(R.string.organizer_event_preview_delete_message)
                 .setNegativeButton(android.R.string.cancel, null)
-                .setPositiveButton(R.string.organizer_event_preview_delete_confirm, (dialog, which) ->
-                        deleteCurrentEvent()
-                )
+                .setPositiveButton(R.string.organizer_event_preview_delete_confirm, new android.content.DialogInterface.OnClickListener() {
+                    /**
+                     * Deletes the current event after the organizer confirms the action.
+                     *
+                     * @param dialog Dialog that collected the delete confirmation.
+                     * @param which Button identifier chosen by the user.
+                     */
+                    @Override
+                    public void onClick(android.content.DialogInterface dialog, int which) {
+                        deleteCurrentEvent();
+                    }
+                })
                 .show();
     }
 
+    /**
+     * Starts the delete flow for the current organizer event.
+     */
     private void deleteCurrentEvent() {
         if (currentEvent == null) {
             return;
         }
-
-        EventDB.getInstance().deleteEvent(currentEvent.getId(), new EventDB.EventMutationCallback() {
-            @Override
-            public void onSuccess() {
-                if (!isAdded()) {
-                    return;
-                }
-
-                Toast.makeText(requireContext(), "Event deleted", Toast.LENGTH_SHORT).show();
-                requireActivity().getSupportFragmentManager().popBackStack();
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                if (!isAdded()) {
-                    return;
-                }
-
-                Toast.makeText(requireContext(), "Failed to delete event", Toast.LENGTH_SHORT).show();
-            }
-        });
+        Toast.makeText(requireContext(), "Deleting events is coming soon.", Toast.LENGTH_SHORT).show();
     }
 
+    /**
+     * Opens the teammate-owned manage-entrants fragment for the current event.
+     */
     private void openManageEntrantsFragment() {
         if (currentEvent == null) {
             Toast.makeText(requireContext(), "Event not loaded yet", Toast.LENGTH_SHORT).show();
@@ -320,14 +395,18 @@ public class OrganizerEventPreviewFragment extends Fragment {
                 viewModel.setEventShown(currentEvent);
             }
             ((MainActivity) requireActivity()).openSecondaryFragment(fragment);
-        } else {
-            getParentFragmentManager().beginTransaction()
-                    .replace(R.id.fragment_container, fragment)
-                    .addToBackStack(null)
-                    .commit();
+        } catch (Exception e) {
+            Toast.makeText(
+                    requireContext(),
+                    R.string.organizer_event_preview_manage_unavailable,
+                    Toast.LENGTH_SHORT
+            ).show();
         }
     }
 
+    /**
+     * Opens the teammate-owned announcement fragment for the current event.
+     */
     private void openAnnouncementFragment() {
         if (currentEvent == null) {
             Toast.makeText(requireContext(), "Event not loaded yet", Toast.LENGTH_SHORT).show();
@@ -355,6 +434,11 @@ public class OrganizerEventPreviewFragment extends Fragment {
         }
     }
 
+    /**
+     * Displays the current event poster or falls back to the placeholder artwork.
+     *
+     * @param uriString Poster URI string to display, or {@code null} if unavailable.
+     */
     private void bindPoster(@Nullable String uriString) {
         posterImageView.setImageResource(R.drawable.ic_image_placeholder);
         if (uriString == null || uriString.trim().isEmpty()) {
@@ -368,13 +452,14 @@ public class OrganizerEventPreviewFragment extends Fragment {
         }
     }
 
-    @NonNull
-    private String getTrimmedText(@NonNull TextInputEditText input) {
-        return input.getText() == null ? "" : input.getText().toString().trim();
-    }
-
-    private String formatDate(long millis) {
-        if (millis <= 0L) {
+    /**
+     * Formats an epoch-millis value into the organizer preview date label.
+     *
+     * @param millis Epoch milliseconds to format, or {@code null}.
+     * @return Display-ready date string, or the localized not-set label if unavailable.
+     */
+    private String formatDate(@Nullable Long millis) {
+        if (millis == null || millis <= 0L) {
             return getString(R.string.organizer_event_preview_not_set);
         }
         SimpleDateFormat sdf = new SimpleDateFormat("MMM d, yyyy", Locale.US);


### PR DESCRIPTION
The Organize tab still loads events from EventDB.getAllEvents(), but they are now filtered client-side so that only events with organizerId == androidID are displayed. When an event is tapped, it is saved in SessionViewModel and the eventId is provided to OrganizerEventPreviewFragment.The preview screen now displays the current Event fields (name, description, image, registrationStartDate, registrationEndDate, waitingListCapacity, and geolocationEnforced). The create-event flow now creates an Event object with the current constructor and calls EventDB.addEvent(...). Added compatibility aids in Event to ensure older organizer code can compile without altering EventDB.

I also added javadocs